### PR TITLE
添加默认输出路径

### DIFF
--- a/DesktopTool/FrmMain.cs
+++ b/DesktopTool/FrmMain.cs
@@ -152,7 +152,7 @@ namespace DesktopTool
                                 }
                                 catch (Exception ex)
                                 {
-                                    MessageBox.Show(string.Format("Error: {0}", ex.Message));
+                                    MessageBox.Show(string.Format("Error while processing file:\n\t{0}\n\t{1}", _processing.FullName, ex.Message));
                                 }
                             }));
                         }

--- a/DesktopTool/NeteaseCrypto.cs
+++ b/DesktopTool/NeteaseCrypto.cs
@@ -214,7 +214,7 @@ namespace DesktopTool
             }
         }
 
-        public void Dump()
+        public void Dump(string toFolder="./Converted")
         {
             int n = 0x8000;
             double totalLen = _file.Length - _file.Position;
@@ -228,7 +228,10 @@ namespace DesktopTool
                 convertName = convertName.Replace(i.ToString(), "");
             }
 
-            string filePath = string.Format("{0}.{1}", convertName, Format);
+            if (!Directory.Exists(toFolder))
+                Directory.CreateDirectory(toFolder);
+
+            string filePath = toFolder + "/" + string.Format("{0}.{1}", convertName, Format);
 
             using (FileStream stream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.Write))
             {

--- a/DesktopTool/NeteaseCrypto.cs
+++ b/DesktopTool/NeteaseCrypto.cs
@@ -298,7 +298,7 @@ namespace DesktopTool
             tag.Title = Name;
             tag.Performers = Artist;
             tag.Album = _cdata.Album;
-            tag.Comment = "Create by netease copyright protected dump tool gui. author 5L";
+            tag.Comment = "Created by netease copyright media dump tool(ncmdump-gui). author 5L";
 
             f.Save();
         }

--- a/DesktopTool/Properties/Resources.resx
+++ b/DesktopTool/Properties/Resources.resx
@@ -122,7 +122,7 @@
     <value>..\Resources\drag.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Normal" xml:space="preserve">
-    <value>Drag `.ncm` files to here</value>
+    <value>Drop '.ncm' files here to start conversion</value>
   </data>
   <data name="Processing" xml:space="preserve">
     <value>Processing "{0}"</value>


### PR DESCRIPTION
* 为`NeteaseCrypto.dump()`方法添加默认的输出路径，转换后的文件不再直接输出应用程序根目录下。
* 修改程序中的部分提示